### PR TITLE
feat: db schema and workflow improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Inspired by the
 [Getting Things Done](https://en.wikipedia.org/wiki/Getting_Things_Done)
 methodology and Ben Solo's iconic shirtless scene, Swolo is a
-**project management and note-taking app** designed for a party of one.
+**project management** and **note-taking app** designed for a party of one.
 
 Capture tasks, manage projects, and take notes with confidence — just like Ben,
 you're swol enough to handle anything your workload throws at you.
@@ -51,7 +51,7 @@ docker compose up -d
 
 Feel free to change the database settings in the `.env` and `docker-compose.yaml` files to your liking.
 
-Then, run the database migrations and seed the database with emails and folders:
+Then, initialize the database and seed it with some tasks and projects:
 
 ```bash
 pnpm db:migrate
@@ -63,6 +63,15 @@ Finally, run the Next.js development server:
 ```bash
 pnpm dev
 ```
+
+> [!NOTE]  
+> While Swolo is in alpha, the db will contain a single migration and seed file
+> for rapid development. After changing the schema, you will need to reinitialize
+> the database (causing all data to be lost):
+>
+> ```
+> pnpm db:reset
+> ```
 
 ## Contributing
 

--- a/app/projects/[key]/page.tsx
+++ b/app/projects/[key]/page.tsx
@@ -1,0 +1,7 @@
+export default function Page({ params }: { params: { key: string } }) {
+  return (
+    <div>
+      <h1>Project {params.key}</h1>
+    </div>
+  );
+}

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -1,48 +1,48 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 import {
   CheckIcon,
   ChevronRightIcon,
   DotFilledIcon,
-} from "@radix-ui/react-icons"
+} from '@radix-ui/react-icons';
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-const DropdownMenu = DropdownMenuPrimitive.Root
+const DropdownMenu = DropdownMenuPrimitive.Root;
 
-const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
 
-const DropdownMenuGroup = DropdownMenuPrimitive.Group
+const DropdownMenuGroup = DropdownMenuPrimitive.Group;
 
-const DropdownMenuPortal = DropdownMenuPrimitive.Portal
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
 
-const DropdownMenuSub = DropdownMenuPrimitive.Sub
+const DropdownMenuSub = DropdownMenuPrimitive.Sub;
 
-const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
 
 const DropdownMenuSubTrigger = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
-    inset?: boolean
+    inset?: boolean;
   }
 >(({ className, inset, children, ...props }, ref) => (
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent",
-      inset && "pl-8",
-      className
+      'flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent',
+      inset && 'pl-8',
+      className,
     )}
     {...props}
   >
     {children}
     <ChevronRightIcon className="ml-auto h-4 w-4" />
   </DropdownMenuPrimitive.SubTrigger>
-))
+));
 DropdownMenuSubTrigger.displayName =
-  DropdownMenuPrimitive.SubTrigger.displayName
+  DropdownMenuPrimitive.SubTrigger.displayName;
 
 const DropdownMenuSubContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
@@ -51,14 +51,14 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-      className
+      'z-50 min-w-32 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+      className,
     )}
     {...props}
   />
-))
+));
 DropdownMenuSubContent.displayName =
-  DropdownMenuPrimitive.SubContent.displayName
+  DropdownMenuPrimitive.SubContent.displayName;
 
 const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
@@ -69,33 +69,33 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-        className
+        'z-50 min-w-32 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md',
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        className,
       )}
       {...props}
     />
   </DropdownMenuPrimitive.Portal>
-))
-DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
+));
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
 
 const DropdownMenuItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
-    inset?: boolean
+    inset?: boolean;
   }
 >(({ className, inset, ...props }, ref) => (
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
-      inset && "pl-8",
-      className
+      'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+      inset && 'pl-8',
+      className,
     )}
     {...props}
   />
-))
-DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
+));
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
 
 const DropdownMenuCheckboxItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
@@ -104,8 +104,8 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      className
+      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      className,
     )}
     checked={checked}
     {...props}
@@ -117,9 +117,9 @@ const DropdownMenuCheckboxItem = React.forwardRef<
     </span>
     {children}
   </DropdownMenuPrimitive.CheckboxItem>
-))
+));
 DropdownMenuCheckboxItem.displayName =
-  DropdownMenuPrimitive.CheckboxItem.displayName
+  DropdownMenuPrimitive.CheckboxItem.displayName;
 
 const DropdownMenuRadioItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
@@ -128,8 +128,8 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      className
+      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      className,
     )}
     {...props}
   >
@@ -140,26 +140,26 @@ const DropdownMenuRadioItem = React.forwardRef<
     </span>
     {children}
   </DropdownMenuPrimitive.RadioItem>
-))
-DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName
+));
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
 
 const DropdownMenuLabel = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Label>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
-    inset?: boolean
+    inset?: boolean;
   }
 >(({ className, inset, ...props }, ref) => (
   <DropdownMenuPrimitive.Label
     ref={ref}
     className={cn(
-      "px-2 py-1.5 text-sm font-semibold",
-      inset && "pl-8",
-      className
+      'px-2 py-1.5 text-sm font-semibold',
+      inset && 'pl-8',
+      className,
     )}
     {...props}
   />
-))
-DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName
+));
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
 
 const DropdownMenuSeparator = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
@@ -167,11 +167,11 @@ const DropdownMenuSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    className={cn('-mx-1 my-1 h-px bg-muted', className)}
     {...props}
   />
-))
-DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName
+));
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
 
 const DropdownMenuShortcut = ({
   className,
@@ -179,27 +179,27 @@ const DropdownMenuShortcut = ({
 }: React.HTMLAttributes<HTMLSpanElement>) => {
   return (
     <span
-      className={cn("ml-auto text-xs tracking-widest opacity-60", className)}
+      className={cn('ml-auto text-xs tracking-widest opacity-60', className)}
       {...props}
     />
-  )
-}
-DropdownMenuShortcut.displayName = "DropdownMenuShortcut"
+  );
+};
+DropdownMenuShortcut.displayName = 'DropdownMenuShortcut';
 
 export {
   DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
   DropdownMenuCheckboxItem,
-  DropdownMenuRadioItem,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuPortal,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuShortcut,
-  DropdownMenuGroup,
-  DropdownMenuPortal,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
-  DropdownMenuRadioGroup,
-}
+  DropdownMenuTrigger,
+};

--- a/db/queries.ts
+++ b/db/queries.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { aliasedTable, and, eq, sql } from 'drizzle-orm';
+import { aliasedTable, eq, sql } from 'drizzle-orm';
 import { db } from './drizzle';
 import { labels, projectLabels, projects, tasks } from './schema';
 import { ProjectWithLabels, Task } from './types';
@@ -72,6 +72,6 @@ export const getProjects = async (
     .leftJoin(labels, eq(projectLabels.labelId, labels.id))
     .limit(limit)
     .offset(offset)
-    .where(and(eq(projects.userId, params.userId)))
+    .where(eq(projects.userId, params.userId))
     .groupBy(projects.id, parentProject.name);
 };

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -7,6 +7,7 @@ import {
   primaryKey,
   text,
   timestamp,
+  unique,
   varchar,
 } from 'drizzle-orm/pg-core';
 
@@ -26,20 +27,26 @@ export const users = pgTable('users', {
 });
 
 // Projects table
-export const projects = pgTable('projects', {
-  id: varchar({ length: cuidLength })
-    .$defaultFn(() => createId())
-    .primaryKey(),
-  name: text().notNull(),
-  description: text(),
-  createdAt: timestamp().defaultNow().notNull(),
-  updatedAt: timestamp().defaultNow().notNull(),
-  parentId: varchar().references((): AnyPgColumn => projects.id),
-  userId: varchar({ length: userIdLength })
-    .references(() => users.id)
-    .notNull(),
-  key: varchar({ length: 30 }),
-});
+export const projects = pgTable(
+  'projects',
+  {
+    id: varchar({ length: cuidLength })
+      .$defaultFn(() => createId())
+      .primaryKey(),
+    name: text().notNull(),
+    description: text(),
+    createdAt: timestamp().defaultNow().notNull(),
+    updatedAt: timestamp().defaultNow().notNull(),
+    parentId: varchar().references((): AnyPgColumn => projects.id),
+    userId: varchar({ length: userIdLength })
+      .references(() => users.id)
+      .notNull(),
+    key: varchar({ length: 20 }).notNull(),
+  },
+  (t) => ({
+    unq: unique().on(t.key, t.userId), // ensure unique project keys for the user
+  }),
+);
 
 // Tasks table
 export const tasks = pgTable('tasks', {
@@ -56,7 +63,6 @@ export const tasks = pgTable('tasks', {
   userId: varchar({ length: userIdLength })
     .references(() => users.id)
     .notNull(),
-  key: varchar({ length: 30 }),
 });
 
 // Labels table

--- a/db/seed.ts
+++ b/db/seed.ts
@@ -1,13 +1,28 @@
 import { getConstants, init } from '@paralleldrive/cuid2';
 import { db } from './drizzle';
-import { projects, tasks, users } from './schema';
+import {
+  labels,
+  projectLabels,
+  projects,
+  taskLabels,
+  tasks,
+  users,
+} from './schema';
 
 const cuidLength = getConstants().bigLength;
 const createId = init({ length: cuidLength });
 
+function createIds(count: number) {
+  return Array.from({ length: count }, createId);
+}
+
+const [labelFeat, labelBug, labelEnhancement, labelHobby, labelDev] =
+  createIds(5);
+
 async function seed() {
   console.log('Starting seed process...');
   await seedUsers();
+  await seedLabels();
   await seedProjects();
   await seedTasks();
 
@@ -24,6 +39,16 @@ async function seedUsers() {
   ]);
 }
 
+async function seedLabels() {
+  await db.insert(labels).values([
+    { id: labelFeat, name: 'feat', userId: 'fox' },
+    { id: labelBug, name: 'bug', userId: 'fox' },
+    { id: labelEnhancement, name: 'enhancement', userId: 'fox' },
+    { id: labelHobby, name: 'hobby', userId: 'fox' },
+    { id: labelDev, name: 'dev', userId: 'fox' },
+  ]);
+}
+
 async function seedProjects() {
   await db.insert(projects).values([
     {
@@ -34,12 +59,20 @@ async function seedProjects() {
       key: 'swolo',
     },
   ]);
+
+  await db.insert(projectLabels).values([
+    { projectId: 'swolo', labelId: labelHobby },
+    { projectId: 'swolo', labelId: labelDev },
+  ]);
 }
 
 async function seedTasks() {
+  const [myTask, designLayout, authModule, setupDb, createApi, frontend] =
+    createIds(6);
+
   await db.insert(tasks).values([
     {
-      id: createId(),
+      id: myTask,
       title: 'Implement synching',
       description: 'Sync data from the cloud to the local desktop.',
       status: 'todo',
@@ -48,50 +81,54 @@ async function seedTasks() {
       key: 'my-task',
     },
     {
-      id: createId(),
+      id: designLayout,
       title: 'Design app layout',
       description: 'Create wireframes and mockups for the app.',
       status: 'in-progress',
       userId: 'fox',
       projectId: 'swolo',
-      key: 'design-layout',
     },
     {
-      id: createId(),
+      id: authModule,
       title: 'Develop authentication module',
       description: 'Implement user login and registration functionality.',
       status: 'todo',
       userId: 'fox',
       projectId: 'swolo',
-      key: 'auth-module',
     },
     {
-      id: createId(),
+      id: setupDb,
       title: 'Set up database',
       description: 'Configure the database schema and connections.',
       status: 'todo',
       userId: 'fox',
       projectId: 'swolo',
-      key: 'setup-database',
     },
     {
-      id: createId(),
+      id: createApi,
       title: 'Create API endpoints',
       description: 'Develop RESTful API endpoints for the app.',
       status: 'todo',
       userId: 'fox',
       projectId: 'swolo',
-      key: 'create-api',
     },
     {
-      id: createId(),
+      id: frontend,
       title: 'Implement frontend',
       description: 'Build the frontend using React.',
       status: 'todo',
       userId: 'fox',
       projectId: 'swolo',
-      key: 'implement-frontend',
     },
+  ]);
+
+  await db.insert(taskLabels).values([
+    { taskId: myTask, labelId: labelFeat },
+    { taskId: designLayout, labelId: labelEnhancement },
+    { taskId: authModule, labelId: labelBug },
+    { taskId: setupDb, labelId: labelFeat },
+    { taskId: createApi, labelId: labelFeat },
+    { taskId: frontend, labelId: labelDev },
   ]);
 }
 

--- a/db/utils.ts
+++ b/db/utils.ts
@@ -1,0 +1,30 @@
+import { and, eq } from 'drizzle-orm';
+import { db } from './drizzle';
+import { projects } from './schema';
+
+export async function generateUniqueProjectKey(
+  userId: string,
+  projectName: string,
+): Promise<string> {
+  let key = '';
+  let isKeyUnique = false;
+  let counter = 0;
+
+  while (!isKeyUnique) {
+    key = projectName.substring(0, 5) + (counter ? counter : '');
+    counter++;
+
+    // Check if the key is already in use by this user
+    const existingProject = await db
+      .select()
+      .from(projects)
+      .where(and(eq(projects.key, key), eq(projects.userId, userId)))
+      .limit(1);
+
+    if (!existingProject.length) {
+      isKeyUnique = true;
+    }
+  }
+
+  return key;
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   postgres:
     image: postgres:17.0-alpine3.20
@@ -11,5 +10,11 @@ services:
       - '5432:5432'
     volumes:
       - db:/var/lib/postgresql/data
+
+  wait-for-it:
+    image: dokku/wait
+    depends_on:
+      - postgres
+    command: -c "postgres:5432" -t 60
 volumes:
   db:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "db:seed": "pnpx tsx db/seed.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "npx tsx db/migrate.ts",
-    "db:studio": "drizzle-kit studio"
+    "db:studio": "drizzle-kit studio",
+    "db:reset": "docker compose down && (docker volume rm swolo_db || true) && docker compose up -d && docker compose run --rm wait-for-it && pnpm db:migrate && pnpm db:seed"
   },
   "dependencies": {
     "@paralleldrive/cuid2": "^2.2.2",


### PR DESCRIPTION
- Adds a new script `db:reset` for reinitializing the db. The script:
  - Stops docker
  - Removes the db volume
  - Restarts docker
  - Creates and seeds the db

- Changes the db schema so that `key`s are required in projects. Keys are user-friendly strings that can be used as a shortcut to the entity. For example, in URL-hacking, or in search. (Keys are not yet supported in tasks).

- Adds more seed data, including labels.

- Adds a stub project page with a dynamic route at `/projects/[key]`.

- Autogenerates project keys (ensuring uniqueness). 

![image](https://github.com/user-attachments/assets/653ef6e5-d24c-4e17-9112-4d22a5746e98)


