### PR TITLE
chore: changes dep updates to weekly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":dependencyDashboard"],
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    "schedule:earlyMondays"
+  ],
   "separateMinorPatch": true,
   "packageRules": [
     {


### PR DESCRIPTION
Changes renovate to update dependencies weekly, early Monday mornings (before 4 AM).
https://docs.renovatebot.com/presets-schedule/#scheduleearlymondays
